### PR TITLE
feat: add metadata support

### DIFF
--- a/pkg/controller/bookmark/load_bookmark.go
+++ b/pkg/controller/bookmark/load_bookmark.go
@@ -23,7 +23,7 @@ func (b *Bookmark) LoadBookmarks() error {
 
 	err = json.Unmarshal([]byte(file), &b.Categories)
 	if err != nil {
-		return fmt.Errorf("failed to read file, maybe corrupted")
+		return fmt.Errorf("failed to read file, maybe corrupted, error: %v", err)
 	}
 
 	return nil

--- a/pkg/controller/grpc/check_grpc.go
+++ b/pkg/controller/grpc/check_grpc.go
@@ -47,7 +47,7 @@ func (g *GRPC) CheckGRPC(serverURL string) error {
 	}
 	g.Conn.DescriptorSource = reflSource
 	log = entity.Log{
-		Content: "🤩 this server support server reflection",
+		Content: "✅ this server support server reflection",
 		Type:    entity.LOG_INFO,
 	}
 	log.DumpLogToChannel(g.LogChannel)

--- a/pkg/entity/app.go
+++ b/pkg/entity/app.go
@@ -1,3 +1,3 @@
 package entity
 
-const APP_VERSION = "0.0.1 ALPHA"
+const APP_VERSION = "0.0.2 ALPHA"

--- a/pkg/entity/metadata.go
+++ b/pkg/entity/metadata.go
@@ -1,0 +1,8 @@
+package entity
+
+type Metadata struct {
+	Active bool
+	Key    string
+	Value  string
+}
+

--- a/pkg/entity/session.go
+++ b/pkg/entity/session.go
@@ -17,14 +17,18 @@ type Session struct {
 	AvailableMethods  []string                 `json:"-"`
 	RequestPayload    string                   `json:"request_payload"`
 	DescriptorSource  grpcurl.DescriptorSource `json:"-"`
-	Metadata          map[string]string        `json:"metadata"`
+	Metadata          []*Metadata              `json:"metadata"`
 }
 
 // ParseMetadata used to convert the metadata and authorization parameters to array of strings
 func (s *Session) ParseMetadata() []string {
+
+	// Convert metadata to array of strings
 	result := make([]string, 0, len(s.Metadata))
-	for k, v := range s.Metadata {
-		result = append(result, k+": "+v)
+	for _, v := range s.Metadata {
+		if v.Active {
+			result = append(result, v.Key+": "+v.Value)
+		}
 	}
 
 	// Add the authorization to header

--- a/pkg/entity/session_test.go
+++ b/pkg/entity/session_test.go
@@ -18,8 +18,12 @@ func TestParseMetadata(t *testing.T) {
 			name: "success, normal request",
 			session: entity.Session{
 				Name: "Session 1",
-				Metadata: map[string]string{
-					"name": "testing-name",
+				Metadata: []*entity.Metadata{
+					{
+						Active: true,
+						Key:    "Authorization",
+						Value:  "Bearer testing-token",
+					},
 				},
 				Authorization: &entity.Auth{
 					AuthType: entity.AuthTypeBearer,
@@ -39,9 +43,14 @@ func TestParseMetadata(t *testing.T) {
 			name: "success, no authorization",
 			session: entity.Session{
 				Name: "Session 1",
-				Metadata: map[string]string{
-					"name": "testing-name",
+				Metadata: []*entity.Metadata{
+					{
+						Active: true,
+						Key:    "Authorization",
+						Value:  "Bearer testing-token",
+					},
 				},
+
 				ServerURL:      "localhost:50051",
 				RequestPayload: "testing-payload",
 			},

--- a/pkg/ui/init_sidebar_menu.go
+++ b/pkg/ui/init_sidebar_menu.go
@@ -21,7 +21,7 @@ func (u *UI) InitSidebarMenu() *tview.List {
 	menuList.AddItem("Request Payload", "", 'p', u.ShowRequestPayloadModal)
 	menuList.AddItem("Invoke", "", 'i', u.InvokeRPC)
 	menuList.AddItem("[::d]"+strings.Repeat(string(tcell.RuneHLine), 25), "", 0, nil)
-	menuList.AddItem("Save to Bookmark", "", 'b', u.ShowSaveToBookmarkModal)
+	menuList.AddItem("Create New Bookmark", "", 'b', u.ShowSaveToBookmarkModal)
 	menuList.AddItem("Quit", "", 'q', u.QuitApplication)
 
 	// Handle keypress on menu list

--- a/pkg/ui/invoke_rpc.go
+++ b/pkg/ui/invoke_rpc.go
@@ -7,6 +7,18 @@ import (
 )
 
 func (u *UI) InvokeRPC() {
+
+	// Construct metadata info
+	var metadata string
+	for _, meta := range u.GRPC.Conn.ParseMetadata() {
+		metadata += "- " + meta + "\n"
+	}
+
+	u.PrintLog(entity.Log{
+		Content: "\nRequest Metadata:\n" + metadata + "\nRequest Payload:\n[yellow]" + u.GRPC.Conn.RequestPayload + "\n",
+		Type:    entity.LOG_INFO,
+	})
+
 	err := u.GRPC.InvokeRPC()
 	if err != nil {
 		u.PrintLog(entity.Log{

--- a/pkg/ui/message_box.go
+++ b/pkg/ui/message_box.go
@@ -10,7 +10,7 @@ import (
 
 type Button struct {
 	Name    string
-	OnClick func()
+	OnClick func(msgboxWnd *winman.WindowBase)
 }
 
 type ShowMessageBoxParam struct {
@@ -40,14 +40,14 @@ func (u *UI) ShowMessageBox(param ShowMessageBoxParam) {
 		fallbackFocus: u.Layout.MenuList,
 	})
 
-	u.ShowMessageBox_SetComponentActions(form, param.buttons)
+	u.ShowMessageBox_SetComponentActions(wnd, form, param.buttons)
 	u.ShowMessageBox_SetInputCapture(wnd, form)
 }
 
-func (u *UI) ShowMessageBox_SetComponentActions(form *tview.Form, buttons []Button) {
+func (u *UI) ShowMessageBox_SetComponentActions(wnd *winman.WindowBase, form *tview.Form, buttons []Button) {
 	// Populate buttons
 	for _, button := range buttons {
-		form.AddButton(button.Name, button.OnClick)
+		form.AddButton(button.Name, func() { button.OnClick(wnd) })
 	}
 }
 

--- a/pkg/ui/show_bookmark_option_modal.go
+++ b/pkg/ui/show_bookmark_option_modal.go
@@ -78,7 +78,7 @@ func (u *UI) populateBookmarkChoices(param populateBookmarkChoicesParam) {
 			buttons: []Button{
 				{
 					Name: "Yes",
-					OnClick: func() {
+					OnClick: func(wnd *winman.WindowBase) {
 						err := u.OverwriteBookmark(param.bookmark)
 						if err != nil {
 							u.PrintLog(entity.Log{
@@ -98,8 +98,8 @@ func (u *UI) populateBookmarkChoices(param populateBookmarkChoicesParam) {
 				},
 				{
 					Name: "No",
-					OnClick: func() {
-						u.CloseModalDialog(param.wnd, *param.parentWnd)
+					OnClick: func(wnd *winman.WindowBase) {
+						u.CloseModalDialog(wnd, *param.parentWnd)
 					},
 				},
 			},
@@ -113,7 +113,7 @@ func (u *UI) populateBookmarkChoices(param populateBookmarkChoicesParam) {
 			buttons: []Button{
 				{
 					Name: "Yes",
-					OnClick: func() {
+					OnClick: func(wnd *winman.WindowBase) {
 						err := u.DeleteBookmark(*param.bookmark)
 						if err != nil {
 							u.PrintLog(entity.Log{
@@ -133,7 +133,7 @@ func (u *UI) populateBookmarkChoices(param populateBookmarkChoicesParam) {
 				},
 				{
 					Name: "No",
-					OnClick: func() {
+					OnClick: func(wnd *winman.WindowBase) {
 						u.CloseModalDialog(param.wnd, *param.parentWnd)
 					},
 				},

--- a/pkg/ui/show_bookmark_option_modal.go
+++ b/pkg/ui/show_bookmark_option_modal.go
@@ -150,10 +150,12 @@ func (u *UI) ApplyBookmark(session entity.Session) {
 	go func() {
 		err := u.GRPC.CheckGRPC(u.GRPC.Conn.ServerURL)
 		if err != nil {
-			u.PrintLog(entity.Log{
-				Content: err.Error(),
-				Type:    entity.LOG_ERROR,
-			})
+			if err != nil {
+				u.PrintLog(entity.Log{
+					Content: "❌ failed to connect to [blue]" + u.GRPC.Conn.ServerURL + " [red]" + err.Error(),
+					Type:    entity.LOG_ERROR,
+				})
+			}
 			return
 		}
 	}()

--- a/pkg/ui/show_bookmark_option_modal.go
+++ b/pkg/ui/show_bookmark_option_modal.go
@@ -150,12 +150,11 @@ func (u *UI) ApplyBookmark(session entity.Session) {
 	go func() {
 		err := u.GRPC.CheckGRPC(u.GRPC.Conn.ServerURL)
 		if err != nil {
-			if err != nil {
-				u.PrintLog(entity.Log{
-					Content: "❌ failed to connect to [blue]" + u.GRPC.Conn.ServerURL + " [red]" + err.Error(),
-					Type:    entity.LOG_ERROR,
-				})
-			}
+			u.PrintLog(entity.Log{
+				Content: "❌ failed to connect to [blue]" + u.GRPC.Conn.ServerURL + " [red]" + err.Error(),
+				Type:    entity.LOG_ERROR,
+			})
+
 			return
 		}
 	}()

--- a/pkg/ui/show_metadata_modal.go
+++ b/pkg/ui/show_metadata_modal.go
@@ -40,15 +40,25 @@ func (u *UI) ShowMetadataModal() {
 		cell := table.GetCell(row, col)
 		u.deleteMetadataModal(wnd, table, cell)
 	})
+
 	form.AddButton("Add Metadata", func() {
 		u.showAddMetadataModal(wnd, table)
+	}).SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		switch event.Key() {
+		case tcell.KeyTab:
+			if form.GetButton(form.GetButtonIndex("Add Metadata")).HasFocus() {
+				u.SetFocus(table)
+			}
+
+		}
+		return event
 	})
 
-	u.ShowMetadataModal_SetComponentActions(wnd, table)
+	u.ShowMetadataModal_SetComponentActions(wnd, table, form)
 	u.ShowMetadataModal_RefreshMetadataTable(table)
 }
 
-func (u *UI) ShowMetadataModal_SetComponentActions(wnd *winman.WindowBase, table *tview.Table) {
+func (u *UI) ShowMetadataModal_SetComponentActions(wnd *winman.WindowBase, table *tview.Table, form *tview.Form) {
 	table.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		switch event.Key() {
 		case tcell.KeyEnter:
@@ -64,6 +74,9 @@ func (u *UI) ShowMetadataModal_SetComponentActions(wnd *winman.WindowBase, table
 
 		case tcell.KeyEscape:
 			u.CloseModalDialog(wnd, u.Layout.MenuList)
+			return nil
+		case tcell.KeyTab:
+			u.SetFocus(form)
 			return nil
 		}
 

--- a/pkg/ui/show_metadata_modal.go
+++ b/pkg/ui/show_metadata_modal.go
@@ -1,8 +1,265 @@
 package ui
 
+import (
+	"github.com/epiclabs-io/winman"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/felangga/chiko/pkg/entity"
+)
+
 func (u *UI) ShowMetadataModal() {
+
+	table := tview.NewTable()
+	table.SetBorders(false).
+		SetSelectable(true, false).
+		SetSeparator(tview.Borders.Vertical).
+		SetBackgroundColor(u.Theme.Colors.WindowColor)
+
+	form := tview.NewForm()
+	form.SetButtonsAlign(tview.AlignRight)
+	form.SetBackgroundColor(u.Theme.Colors.WindowColor)
+
+	flex := tview.NewFlex()
+	flex.SetBorderPadding(1, 0, 1, 1)
+	flex.SetDirection(tview.FlexRow)
+	flex.AddItem(table, 0, 8, true)
+	flex.AddItem(form, 0, 1, false)
+
+	wnd := u.CreateModalDialog(CreateModalDiaLog{
+		title:         " 📖 Metadata ",
+		rootView:      flex,
+		draggable:     true,
+		resizeable:    false,
+		size:          winSize{0, 0, 100, 30},
+		fallbackFocus: u.Layout.MenuList,
+	})
+
+	form.AddButton("Delete Metadata", func() {
+		row, col := table.GetSelection()
+		cell := table.GetCell(row, col)
+		u.deleteMetadataModal(wnd, table, cell)
+	})
+	form.AddButton("Add Metadata", func() {
+		u.showAddMetadataModal(wnd, table)
+	})
+
+	u.ShowMetadataModal_SetComponentActions(wnd, table)
+	u.ShowMetadataModal_RefreshMetadataTable(table)
+}
+
+func (u *UI) ShowMetadataModal_SetComponentActions(wnd *winman.WindowBase, table *tview.Table) {
+	table.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		switch event.Key() {
+		case tcell.KeyEnter:
+			// If no metadata, do nothing
+			if u.GRPC.Conn.Metadata == nil {
+				return event
+			}
+
+			row, col := table.GetSelection()
+			cell := table.GetCell(row, col)
+
+			u.showEditMetadataModal(wnd, table, cell)
+
+		case tcell.KeyEscape:
+			u.CloseModalDialog(wnd, u.Layout.MenuList)
+			return nil
+		}
+
+		return event
+	})
+
+	table.SetMouseCapture(func(action tview.MouseAction, event *tcell.EventMouse) (tview.MouseAction, *tcell.EventMouse) {
+		if action == tview.MouseLeftDoubleClick {
+			// If no metadata, do nothing
+			if u.GRPC.Conn.Metadata == nil {
+				return action, event
+			}
+			row, col := table.GetSelection()
+			cell := table.GetCell(row, col)
+
+			u.showEditMetadataModal(wnd, table, cell)
+		}
+		return action, event
+	})
+}
+
+func (u *UI) ShowMetadataModal_RefreshMetadataTable(table *tview.Table) {
+	table.Clear()
+
+	// Set headers
+	table.SetCell(0, 0, tview.NewTableCell("Active").
+		SetTextColor(tcell.ColorYellow).
+		SetAlign(tview.AlignCenter).
+		SetExpansion(1).
+		SetSelectable(false))
+
+	table.SetCell(0, 1, tview.NewTableCell("Key").
+		SetTextColor(tcell.ColorYellow).
+		SetAlign(tview.AlignCenter).
+		SetExpansion(3).
+		SetSelectable(false))
+
+	table.SetCell(0, 2, tview.NewTableCell("Value").
+		SetTextColor(tcell.ColorYellow).
+		SetAlign(tview.AlignCenter).
+		SetExpansion(4).
+		SetSelectable(false))
+
+	// Populate the table with data
+	for row, meta := range u.GRPC.Conn.Metadata {
+		// Active indicator
+		activeCell := "✖"
+		if meta.Active {
+			activeCell = "✔"
+		}
+
+		table.SetCell(row+1, 0, tview.NewTableCell(activeCell).
+			SetAlign(tview.AlignCenter).
+			SetReference(meta).
+			SetSelectable(true))
+
+		// Key
+		table.SetCell(row+1, 1, tview.NewTableCell(meta.Key).
+			SetAlign(tview.AlignLeft).
+			SetReference(meta).
+			SetSelectable(true))
+
+		// Value
+		table.SetCell(row+1, 2, tview.NewTableCell(meta.Value).
+			SetAlign(tview.AlignLeft).
+			SetReference(meta).
+			SetSelectable(true))
+	}
+
+}
+
+func (u *UI) showAddMetadataModal(parentWnd *winman.WindowBase, table *tview.Table) {
+	form := tview.NewForm()
+	form.SetBackgroundColor(u.Theme.Colors.WindowColor)
+	form.SetButtonsAlign(tview.AlignRight)
+
+	inpKey := tview.NewInputField()
+	inpKey.SetLabel("Key")
+	form.AddFormItem(inpKey)
+
+	inpValue := tview.NewInputField()
+	inpValue.SetLabel("Value")
+	form.AddFormItem(inpValue)
+
+	chkActive := tview.NewCheckbox()
+	chkActive.SetChecked(true)
+	chkActive.SetLabel("Active")
+	form.AddFormItem(chkActive)
+
+	wnd := u.CreateModalDialog(CreateModalDiaLog{
+		title:         " Add Metadata ",
+		rootView:      form,
+		draggable:     true,
+		resizeable:    false,
+		size:          winSize{0, 0, 50, 11},
+		fallbackFocus: parentWnd,
+	})
+
+	form.AddButton("Cancel", func() {
+		u.CloseModalDialog(wnd, parentWnd)
+	})
+
+	form.AddButton("Save", func() {
+		// Create new metadata
+		metadata := &entity.Metadata{
+			Active: chkActive.IsChecked(),
+			Key:    inpKey.GetText(),
+			Value:  inpValue.GetText(),
+		}
+
+		u.GRPC.Conn.Metadata = append(u.GRPC.Conn.Metadata, metadata)
+		u.ShowMetadataModal_RefreshMetadataTable(table)
+
+		u.CloseModalDialog(wnd, parentWnd)
+	})
+}
+
+func (u *UI) showEditMetadataModal(parentWnd *winman.WindowBase, table *tview.Table, cell *tview.TableCell) {
+	metadata := cell.GetReference().(*entity.Metadata)
+
+	form := tview.NewForm()
+	form.SetBackgroundColor(u.Theme.Colors.WindowColor)
+	form.SetButtonsAlign(tview.AlignRight)
+
+	inpKey := tview.NewInputField()
+	inpKey.SetLabel("Key")
+	inpKey.SetText(metadata.Key)
+	form.AddFormItem(inpKey)
+
+	inpValue := tview.NewInputField()
+	inpValue.SetLabel("Value")
+	inpValue.SetText(metadata.Value)
+	form.AddFormItem(inpValue)
+
+	chkActive := tview.NewCheckbox()
+	chkActive.SetChecked(metadata.Active)
+	chkActive.SetLabel("Active")
+	form.AddFormItem(chkActive)
+
+	wnd := u.CreateModalDialog(CreateModalDiaLog{
+		title:         " Edit Metadata ",
+		rootView:      form,
+		draggable:     true,
+		resizeable:    false,
+		size:          winSize{0, 0, 50, 11},
+		fallbackFocus: parentWnd,
+	})
+
+	form.AddButton("Cancel", func() {
+		u.CloseModalDialog(wnd, parentWnd)
+	})
+
+	form.AddButton("Save", func() {
+		// Create new metadata
+		metadata.Active = chkActive.IsChecked()
+		metadata.Key = inpKey.GetText()
+		metadata.Value = inpValue.GetText()
+
+		u.ShowMetadataModal_RefreshMetadataTable(table)
+
+		u.CloseModalDialog(wnd, parentWnd)
+	})
+}
+
+func (u *UI) deleteMetadataModal(parentWnd *winman.WindowBase, table *tview.Table, cell *tview.TableCell) {
 	u.ShowMessageBox(ShowMessageBoxParam{
-		title:   " ✨ Coming Soon ",
-		message: "This feature is not yet implemented. Please stay tuned for the next update.",
+		title:   "Delete Metadata",
+		message: "Are you sure you want to delete this metadata?",
+		buttons: []Button{
+			{
+				Name: "Yes",
+				OnClick: func(wnd *winman.WindowBase) {
+					metadata := cell.GetReference().(*entity.Metadata)
+
+					// Delete the metadata from the table
+					// Find the index of the metadata in the slice
+					var indexToRemove int
+					for i, meta := range u.GRPC.Conn.Metadata {
+						if meta == metadata {
+							indexToRemove = i
+							break
+						}
+					}
+					// Remove the metadata from the slice
+					u.GRPC.Conn.Metadata = append(u.GRPC.Conn.Metadata[:indexToRemove], u.GRPC.Conn.Metadata[indexToRemove+1:]...)
+
+					u.ShowMetadataModal_RefreshMetadataTable(table)
+					u.CloseModalDialog(wnd, parentWnd)
+				},
+			},
+			{
+				Name: "No",
+				OnClick: func(wnd *winman.WindowBase) {
+					u.CloseModalDialog(wnd, parentWnd)
+				},
+			},
+		},
 	})
 }

--- a/pkg/ui/show_set_server_url_modal.go
+++ b/pkg/ui/show_set_server_url_modal.go
@@ -2,9 +2,10 @@ package ui
 
 import (
 	"github.com/epiclabs-io/winman"
-	"github.com/felangga/chiko/pkg/entity"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+
+	"github.com/felangga/chiko/pkg/entity"
 )
 
 func (u *UI) ShowSetServerURLModal() {

--- a/pkg/ui/show_set_server_url_modal.go
+++ b/pkg/ui/show_set_server_url_modal.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"github.com/epiclabs-io/winman"
+	"github.com/felangga/chiko/pkg/entity"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -31,7 +32,15 @@ func (u *UI) ShowSetServerURLModal_SetInputCapture(wnd *winman.WindowBase, inp *
 			return nil
 
 		case tcell.KeyEnter:
-			go u.GRPC.CheckGRPC(inp.GetText())
+			go func() {
+				err := u.GRPC.CheckGRPC(inp.GetText())
+				if err != nil {
+					u.PrintLog(entity.Log{
+						Content: "❌ failed to connect to [blue]" + inp.GetText() + " [red]" + err.Error(),
+						Type:    entity.LOG_ERROR,
+					})
+				}
+			}()
 
 			// Remove the window and restore focus to menu list
 			u.WinMan.RemoveWindow(wnd)


### PR DESCRIPTION
## Summary

This PR introduces metadata support, now you can add metadata headers for the request payload.
The metadata contains of the key, value, and status active. You can switch on and off the metadata, whether you want to send the metadata or not. 

https://github.com/user-attachments/assets/a12132a0-0acb-4f38-abeb-60de6a33a1ca

