### PR TITLE
fix(bookmark): set name after overwrite

### DIFF
--- a/pkg/ui/show_bookmark_option_modal.go
+++ b/pkg/ui/show_bookmark_option_modal.go
@@ -202,6 +202,8 @@ func (u *UI) OverwriteBookmark(b *entity.Session) error {
 		for j, session := range category.Sessions {
 			if session.ID == b.ID {
 				category.Sessions[j] = *u.GRPC.Conn
+				category.Sessions[j].Name = session.Name
+
 				return u.Bookmark.SaveBookmark()
 			}
 		}


### PR DESCRIPTION
## Summary

Currently, when you overwrite the existing bookmark, the bookmark name is gone. This PR fixes the overwrite function on the bookmark feature by setting the bookmark name after the overwrite is successful. 